### PR TITLE
Let six version float

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
         '': ['*.txt'],
     },
     install_requires=[
-        'six==1.11.0',
+        'six>=1.11.0',
     ],
 )


### PR DESCRIPTION
The latest version of "six" is six 1.16.0 and some other modules require versions higher than the one loosejson is pinned to.

Packages should generally let their dependencies float otherwise upstream applications end up with a mess of conflicting versions.
